### PR TITLE
DP-2204: Allow for customisation of Rack::Protection middleware

### DIFF
--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -46,8 +46,6 @@ module Flipper
       builder = Rack::Builder.new
       yield builder if block_given?
       builder.use Rack::Protection, rack_protection_options
-      builder.use Rack::Protection
-      builder.use Rack::Protection::AuthenticityToken
       builder.use Rack::MethodOverride
       builder.use Flipper::Middleware::SetupEnv, flipper, env_key: env_key
       builder.use Flipper::Middleware::Memoizer, env_key: env_key

--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -41,14 +41,17 @@ module Flipper
 
     def self.app(flipper = nil, options = {})
       env_key = options.fetch(:env_key, 'flipper')
+      rack_protection_options = options.fetch(:rack_protection, use: :authenticity_token)
       app = ->() { [200, { 'Content-Type' => 'text/html' }, ['']] }
       builder = Rack::Builder.new
       yield builder if block_given?
+      builder.use Rack::Protection, rack_protection_options
       builder.use Rack::Protection
       builder.use Rack::Protection::AuthenticityToken
       builder.use Rack::MethodOverride
       builder.use Flipper::Middleware::SetupEnv, flipper, env_key: env_key
       builder.use Flipper::Middleware::Memoizer, env_key: env_key
+      builder.use Flipper::UI::Middleware, env_key: env_key
       builder.use Middleware, env_key: env_key
       builder.run app
       klass = self


### PR DESCRIPTION
This allows us to customize the `rack-protection` env variables. As it is now, we are using the middleware's hardcoded values which makes it hard to disable some features such as `http_origin` which we need for us to be able to put the Kafka admin tool to run behind turnstile.